### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 
 # NeoCode-tiny-regex
-An incomplete port of [tiny-regex-c](https://github.com/kokke/tiny-regex-c) to native FileMaker custom functions
+An incomplete regex implementation on native FileMaker custom functions
 
 ### Supported regex-operators
 The following features / regex-operators are supported by this library.


### PR DESCRIPTION
The filemaker source code is so removed from original c code that it might as well be considered its own thing (no classes. char arrays, enums, etc).